### PR TITLE
Docker & DB improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:8-jdk-alpine
 VOLUME /tmp
 EXPOSE 8080
-ADD build/libs/live-streaming-0.0.1-SNAPSHOT.jar app.jar
+ADD build/libs/live-streaming.jar app.jar
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: up down build clean
+
+up:
+	docker-compose up -d --build
+
+down:
+	docker-compose down
+
+build:
+	./gradlew build
+
+clean:
+	./gradlew clean

--- a/README.md
+++ b/README.md
@@ -12,45 +12,25 @@ To run this application, use the following Gradle command:
 ./gradlew bootRun
 ```
 
+## Usage (Docker)
+In order to use the Docker version of the app, it is needed docker-compose.
+To build the application, run the following command:
+```bash
+live-streaming$ make build
+```
+To run the containers (both the application and the MySQL database), run the following command:
+```bash
+live-streaming$ make up
+```
+To stop the containers, use the following command:
+```bash
+live-streaming$ make down
+```
+
 ## Documentation
 When the application is running, the documentation is available at the following link:
 ```text
 http://localhost:8080/swagger-ui.html
-```
-
-## Database
-Following SQL script is used to create a MySQL database for storing users and videos data.
-```sql
-#create database
-CREATE DATABASE live-stremaing;
-
-#switch to newly created database
-USE live-streaming;
-
-#create users table
-CREATE TABLE `users` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `username` varchar(45) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `password` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `created` datetime DEFAULT NULL,
-  `modified` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `username` (`username`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-#create videos table
-CREATE TABLE `videos` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `user_id` int(10) unsigned NOT NULL,
-  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `size` double DEFAULT NULL,
-  `url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `created` datetime DEFAULT NULL,
-  `modified` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `fk_videos_users_idx` (`user_id`),
-  CONSTRAINT `fk_videos_users` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 ```
 
 ## License

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
-        classpath('gradle.plugin.com.palantir.gradle.docker:gradle-docker:0.20.1')
     }
 }
 
@@ -18,10 +17,7 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
-apply plugin: 'com.palantir.docker'
 
-group = 'com.streaming'
-version = '0.0.1-SNAPSHOT'
 sourceCompatibility = 1.8
 
 repositories {
@@ -38,11 +34,4 @@ dependencies {
     compile("io.springfox:springfox-spring-web:2.9.2")
     runtime('mysql:mysql-connector-java')
     testCompile('org.springframework.boot:spring-boot-starter-test')
-}
-
-docker {
-    dependsOn build
-    name "${project.group}/${bootJar.baseName}"
-    files bootJar.archivePath
-    buildArgs(['JAR_FILE': "${bootJar.archiveName}"])
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  mysql:
+    image: mysql:latest
+    container_name: streaming-mysql
+    ports:
+      - "6033:3306"
+    volumes:
+      - ./mysql_init:/docker-entrypoint-initdb.d/
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: live-streaming
+
+  live-streaming:
+    image: live-streaming
+    container_name: live-streaming
+    restart: on-failure
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8080:8080
+    environment:
+      MYSQL_HOST: streaming-mysql
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: live-streaming

--- a/mysql_init/init.sql
+++ b/mysql_init/init.sql
@@ -1,0 +1,27 @@
+#switch to newly created database
+USE live-streaming;
+
+#create users table
+CREATE TABLE `users` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `username` varchar(45) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `password` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created` datetime DEFAULT NULL,
+  `modified` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `username` (`username`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+#create videos table
+CREATE TABLE `videos` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(10) unsigned NOT NULL,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `size` double DEFAULT NULL,
+  `url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created` datetime DEFAULT NULL,
+  `modified` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_videos_users_idx` (`user_id`),
+  CONSTRAINT `fk_videos_users` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 #MySQL data source properties
-spring.datasource.url=jdbc:mysql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?useUnicode=true&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
-spring.datasource.username=${DATABASE_USER}
-spring.datasource.password=${DATABASE_PASSWORD}
+spring.datasource.url=jdbc:mysql://${MYSQL_HOST}:3306/${MYSQL_DATABASE}?useUnicode=true&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.username=root
+spring.datasource.password=${MYSQL_ROOT_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 spring.jpa.generate-ddl=true
 


### PR DESCRIPTION
Slightly modified application.properties. Replaced palantir with docker-compose (standard). Added docker-compose. Added Makefile (docker-compose & gradle shorthands). Automatic DB init using sql script (mysql_init directory).